### PR TITLE
Fixing typos in method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pyodrx
-pyodrx is a Python wrapper for generating OpenDRIVE 1.4 xml files. 
+pyodrx is a Python wrapper for generating OpenDRIVE 1.5 xml files. 
 Please note that this is not an official implementation.
 
 Work in progress, supported right now is creation of geometries, lanesections (with roadmarker), and junctions including some automation of 

--- a/pyodrx/geometry.py
+++ b/pyodrx/geometry.py
@@ -141,7 +141,7 @@ class PlanView():
             set_start_point(x_start,y_start,h_start)
                 sets the start point and heading of the planview
 
-            adjust_geometires()
+            adjust_geometries()
                 based on the start point, it will adjust all geometries in the planview
 
     """
@@ -232,7 +232,7 @@ class PlanView():
 
         return self.x_end, self.y_end, self.h_end 
 
-    def adjust_geometires(self, from_end=False):
+    def adjust_geometries(self, from_end=False):
         """ Adjusts all geometries to have the correct start point and heading
 
             Parameters


### PR DESCRIPTION
Recently, I have started using your wrapper and I have noticed several typos in method names. This PR is about correcting a few of them.

Thanks for this great project !