### PR TITLE
Make examples more generic by creating xodr output files

### DIFF
--- a/examples/full_junction.py
+++ b/examples/full_junction.py
@@ -32,4 +32,8 @@ for j in junc:
 
 odr.adjust_roads_and_lanes()
 
-pyodrx.run_road(odr,os.path.join('..','pyoscx','esmini')) 
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/highway_example.py
+++ b/examples/highway_example.py
@@ -65,5 +65,8 @@ odr.adjust_roads_and_lanes()
 odr.add_junction(exit_junction)
 odr.add_junction(entry_junction)
 
-# display the road using esmini
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/junction_trippel_twoway.py
+++ b/examples/junction_trippel_twoway.py
@@ -4,7 +4,7 @@ import os
 
 
 
-rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
+rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2)
 
 # create geometries
 

--- a/examples/junction_trippel_twoway.py
+++ b/examples/junction_trippel_twoway.py
@@ -116,4 +116,9 @@ junction.add_connection(con6)
 odr.add_junction(junction)
 odr.adjust_roads_and_lanes()
 # pyodrx.prettyprint(odr.get_element())
-pyodrx.run_road(odr,os.path.join('..','pyoscx','esmini'))
+
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/junction_with_signals.py
+++ b/examples/junction_with_signals.py
@@ -34,6 +34,9 @@ for j in junc:
     odr.add_road(j)
 
 odr.adjust_roads_and_lanes()
-#pyodrx.run_road(odr, os.path.join("..", "pyoscx", "esmini"))
 
+# write the OpenDRIVE file as xodr using current script name
 odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/lane_number_change_merge.py
+++ b/examples/lane_number_change_merge.py
@@ -68,5 +68,8 @@ odr.add_road(road)
 # adjust the roads and lanes
 odr.adjust_roads_and_lanes()
 
-# view the road
-pyodrx.run_road(odr,'/home/mander76/local/scenario_creation/esmini')
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/lane_number_change_merge.py
+++ b/examples/lane_number_change_merge.py
@@ -9,8 +9,8 @@ planview.add_geometry(pyodrx.Line(500))
 
 
 # create two different roadmarkings
-rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
-rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2,rule=pyodrx.MarkRule.no_passing)
+rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2)
+rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2)
 
 # create a centerlane (same centerlane can be used since no linking is needed for this)
 centerlane = pyodrx.Lane(a=2)

--- a/examples/multiple_geometries_one_road.py
+++ b/examples/multiple_geometries_one_road.py
@@ -61,6 +61,8 @@ odr.adjust_roads_and_lanes()
 ##13. Print the .xodr file
 pyodrx.prettyprint(odr.get_element())
 
-##13. Run the .xodr with esmini 
-pyodrx.run_road(odr,os.path.join('..','pyoscx','esmini'))
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
 
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/multiple_geometries_one_road.py
+++ b/examples/multiple_geometries_one_road.py
@@ -23,7 +23,7 @@ planview.add_geometry(line3)
 
 
 ##3. Create a solid roadmark
-rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
+rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2)
 
 ##4. Create centerlane 
 centerlane = pyodrx.Lane(a=2)

--- a/examples/multiple_geometries_one_road_with_objects.py
+++ b/examples/multiple_geometries_one_road_with_objects.py
@@ -22,7 +22,7 @@ planview.add_geometry(line3)
 
 
 ##3. Create a solid roadmark
-rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
+rm = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2)
 
 ##4. Create centerlane 
 centerlane = pyodrx.Lane(a=2)

--- a/examples/multiple_geometries_one_road_with_objects.py
+++ b/examples/multiple_geometries_one_road_with_objects.py
@@ -78,6 +78,8 @@ road.add_object(jerseyBarrier)
 ##15. Print the .xodr file
 pyodrx.prettyprint(odr.get_element())
 
-##16. Write .xodr file
+# write the OpenDRIVE file as xodr using current script name
 odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
 
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/road_merge.py
+++ b/examples/road_merge.py
@@ -34,5 +34,9 @@ for r in roads:
     odr.add_road(r)
 odr.adjust_roads_and_lanes()
 odr.add_junction(junction)
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
 
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/road_merge_w_lane_merge.py
+++ b/examples/road_merge_w_lane_merge.py
@@ -17,8 +17,8 @@ planview = pyodrx.PlanView()
 planview.add_geometry(pyodrx.Line(200))
 
 # create two different roadmarkings
-rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
-rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2,rule=pyodrx.MarkRule.no_passing)
+rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2)
+rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2)
 
 # create a centerlane (same centerlane can be used since no linking is needed for this)
 centerlane = pyodrx.Lane(a=2)

--- a/examples/road_merge_w_lane_merge.py
+++ b/examples/road_merge_w_lane_merge.py
@@ -113,5 +113,9 @@ for r in roads:
     odr.add_road(r)
 odr.adjust_roads_and_lanes()
 odr.add_junction(junction)
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
 
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
+
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/road_split.py
+++ b/examples/road_split.py
@@ -32,6 +32,8 @@ for r in roads:
 odr.adjust_roads_and_lanes()
 odr.add_junction(junction)
 
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
 
-# display the road using esmini
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/road_split_w_lane_split.py
+++ b/examples/road_split_w_lane_split.py
@@ -105,6 +105,8 @@ for r in roads:
 odr.adjust_roads_and_lanes()
 odr.add_junction(junction)
 
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
 
-# display the road using esmini
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/examples/road_split_w_lane_split.py
+++ b/examples/road_split_w_lane_split.py
@@ -10,8 +10,8 @@ planview.add_geometry(pyodrx.Line(200))
 
 
 # create two different roadmarkings
-rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,rule=pyodrx.MarkRule.no_passing)
-rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2,rule=pyodrx.MarkRule.no_passing)
+rm_solid = pyodrx.RoadMark(pyodrx.RoadMarkType.solid,0.2,
+rm_dashed = pyodrx.RoadMark(pyodrx.RoadMarkType.broken,0.2)
 
 
 # create a centerlane (same centerlane can be used since no linking is needed for this)

--- a/examples/two_roads.py
+++ b/examples/two_roads.py
@@ -78,5 +78,8 @@ odr.add_road(road2)
 odr.adjust_roads_and_lanes()
 pyodrx.prettyprint(odr.get_element())
 
-pyodrx.run_road(odr,os.path.join('..','..','esmini'))
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py','.xodr'))
 
+# uncomment the following line to display the road using esmini
+# pyodrx.run_road(odr,os.path.join('..','..','esmini'))

--- a/pyodrx/generators.py
+++ b/pyodrx/generators.py
@@ -27,7 +27,7 @@ def standard_lane(offset=3,rm = STD_ROADMARK_BROKEN):
                 default: 3
 
             rm (RoadMark): road mark used for the standard lane
-                default:  RoadMark(RoadMarkType.solid,0.2,rule=MarkRule.no_passing)
+                default:  RoadMark(STD_ROADMARK_BROKEN)
         Returns
         -------
             lane (Lane): the lane


### PR DESCRIPTION
As we discussed the examples would be more generic (and easier to use for us) if they output xodr files instead of running esmini. Also the more generic roadmarks would be preferred as the additional rule would require further attributes that are not provided. Not sure if this is in your / esmini interest though. This one should be easier to review and it's also my last planned PR for the time being.
Changes are:
- further attributes are not provided so removing MarkRules to generate more generic roadmark
- put run in esmini as comment and per default write an xodr with filename taken from script
- adjust default in generator to used roadmark